### PR TITLE
MIT-208

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -162,14 +162,26 @@ jobs:
 
     - name: Configure docker
       run: |
-        gcloud auth configure-docker us-central1-docker.pkg.dev -q
+        gcloud auth configure-docker ${{ inputs.location }}-docker.pkg.dev -q
+
+    - name: Check if docker build is required
+      shell: bash
+      run: |-
+        OUTPUT=$(gcloud container images list-tags ${{ inputs.location }}-docker.pkg.dev/${{ inputs.repository_project_id }}/${{ inputs.repository }}/${{ inputs.image }})
+        if echo "$OUTPUT" | grep -q "${{ env.VERSION }}"; then
+          echo "SHOULD_BUILD=no"  >> $GITHUB_ENV
+        else
+          echo "SHOULD_BUILD=yes"  >> $GITHUB_ENV
+        fi
 
     - name: Run Docker Build
+      if: env.SHOULD_BUILD == yes
       shell: bash
       run: |-
         make ${{ inputs.docker_target }}
 
     - name: Publish the Docker image to Google Container Registry
+      if: env.SHOULD_BUILD == yes
       shell: bash
       run: |-
         docker tag ${{ inputs.location }}-docker.pkg.dev/${{ inputs.repository_project_id }}/${{ inputs.repository }}/${{ inputs.image }}:${{ env.RAW_VERSION }} ${{ inputs.location }}-docker.pkg.dev/${{ inputs.repository_project_id }}/${{ inputs.repository }}/${{ inputs.image }}:${{ env.VERSION }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -174,15 +174,16 @@ jobs:
         else
           echo "SHOULD_BUILD=yes" >> $GITHUB_OUTPUT
         fi
+        echo "Will we be creating a new docker image? ${SHOULD_BUILD}"
 
     - name: Run Docker Build
-      if: ${{ steps.needs_docker_build.outputs.SHOULD_BUILD }} == yes
+      if: ${{ steps.needs_docker_build.outputs.SHOULD_BUILD == 'yes' }}
       shell: bash
       run: |-
         make ${{ inputs.docker_target }}
 
     - name: Publish the Docker image to Google Container Registry
-      if: ${{ steps.needs_docker_build.outputs.SHOULD_BUILD }} == yes
+      if: ${{ steps.needs_docker_build.outputs.SHOULD_BUILD == 'yes' }}
       shell: bash
       run: |-
         docker tag ${{ inputs.location }}-docker.pkg.dev/${{ inputs.repository_project_id }}/${{ inputs.repository }}/${{ inputs.image }}:${{ env.RAW_VERSION }} ${{ inputs.location }}-docker.pkg.dev/${{ inputs.repository_project_id }}/${{ inputs.repository }}/${{ inputs.image }}:${{ env.VERSION }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -165,23 +165,24 @@ jobs:
         gcloud auth configure-docker ${{ inputs.location }}-docker.pkg.dev -q
 
     - name: Check if docker build is required
+      id: needs_docker_build
       shell: bash
       run: |-
         OUTPUT=$(gcloud container images list-tags ${{ inputs.location }}-docker.pkg.dev/${{ inputs.repository_project_id }}/${{ inputs.repository }}/${{ inputs.image }})
         if echo "$OUTPUT" | grep -q "${{ env.VERSION }}"; then
-          echo "SHOULD_BUILD=no"  >> $GITHUB_ENV
+          echo "SHOULD_BUILD=no"  >> $GITHUB_OUTPUT
         else
-          echo "SHOULD_BUILD=yes"  >> $GITHUB_ENV
+          echo "SHOULD_BUILD=yes" >> $GITHUB_OUTPUT
         fi
 
     - name: Run Docker Build
-      if: env.SHOULD_BUILD == yes
+      if: ${{ steps.needs_docker_build.outputs.SHOULD_BUILD }} == yes
       shell: bash
       run: |-
         make ${{ inputs.docker_target }}
 
     - name: Publish the Docker image to Google Container Registry
-      if: env.SHOULD_BUILD == yes
+      if: ${{ steps.needs_docker_build.outputs.SHOULD_BUILD }} == yes
       shell: bash
       run: |-
         docker tag ${{ inputs.location }}-docker.pkg.dev/${{ inputs.repository_project_id }}/${{ inputs.repository }}/${{ inputs.image }}:${{ env.RAW_VERSION }} ${{ inputs.location }}-docker.pkg.dev/${{ inputs.repository_project_id }}/${{ inputs.repository }}/${{ inputs.image }}:${{ env.VERSION }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -171,10 +171,12 @@ jobs:
         OUTPUT=$(gcloud container images list-tags ${{ inputs.location }}-docker.pkg.dev/${{ inputs.repository_project_id }}/${{ inputs.repository }}/${{ inputs.image }})
         if echo "$OUTPUT" | grep -q "${{ env.VERSION }}"; then
           echo "SHOULD_BUILD=no"  >> $GITHUB_OUTPUT
+          echo "We will not be creating a new docker image"
         else
           echo "SHOULD_BUILD=yes" >> $GITHUB_OUTPUT
+          echo "We will be creating a new docker image"
         fi
-        echo "Will we be creating a new docker image? ${SHOULD_BUILD}"
+        
 
     - name: Run Docker Build
       if: ${{ steps.needs_docker_build.outputs.SHOULD_BUILD == 'yes' }}


### PR DESCRIPTION
Currently, our `cd` pipeline builds images regardless of whether or not they exist. We are going to optimize things so that we only build images whenever they are absent. This should actually improve our app reset pipelines.

For example, ml-dealer-app nightly reset takes 6mins a day to build a docker image when it already exists. That’s 42 minutes a week or 160 minutes a month which is more than 5% of our GHA budget. 

![image](https://user-images.githubusercontent.com/89033050/200387019-b27982fb-f93f-45e7-8284-97739b560d96.png)
